### PR TITLE
add missing dep to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+sounddevice
 vosk


### PR DESCRIPTION
it is used and required in the README, so I was surprised it's not listed here.